### PR TITLE
修改 spring 八股中的注释逻辑错误

### DIFF
--- a/docs/src/sidebar/sanfene/spring.md
+++ b/docs/src/sidebar/sanfene/spring.md
@@ -3310,7 +3310,7 @@ protected AutoConfigurationEntry getAutoConfigurationEntry(AnnotationMetadata an
     // 根据注解属性解析出需要排除的自动配置类。
     Set<String> exclusions = getExclusions(annotationMetadata, attributes);
 
-    // 检查排除的类是否存在于候选配置中，如果存在，则抛出异常。
+    // 检查排除的类是否出现在候选配置中，如果需要排除的类存在但没有出现在候选配置中，则抛出异常。
     checkExcludedClasses(configurations, exclusions);
 
     // 从候选配置中移除排除的类。


### PR DESCRIPTION
# **错误出处**
[34.🌟SpringBoot 自动配置原理了解吗？](https://javabetter.cn/sidebar/sanfene/spring.html#_34-%F0%9F%8C%9Fspringboot-%E8%87%AA%E5%8A%A8%E9%85%8D%E7%BD%AE%E5%8E%9F%E7%90%86%E4%BA%86%E8%A7%A3%E5%90%97)
`getAutoConfigurationEntry()` 方法的源码注释
```java
    // 检查排除的类是否存在于候选配置中，如果存在，则抛出异常。
    checkExcludedClasses(configurations, exclusions);
```

根据源码：
```java
    private void checkExcludedClasses(List<String> configurations, Set<String> exclusions) {
        List<String> invalidExcludes = new ArrayList(exclusions.size());

        for(String exclusion : exclusions) {
            // 这里是在检测exclusion类存在且没有出现在configurations中
            if (ClassUtils.isPresent(exclusion, this.getClass().getClassLoader()) && !configurations.contains(exclusion)) {
                invalidExcludes.add(exclusion);
            }
        }

        if (!invalidExcludes.isEmpty()) {
            this.handleInvalidExcludes(invalidExcludes);
        }
    }

    protected void handleInvalidExcludes(List<String> invalidExcludes) {
        StringBuilder message = new StringBuilder();

        for(String exclude : invalidExcludes) {
            message.append("\t- ").append(exclude).append(String.format("%n"));
        }

        throw new IllegalStateException(String.format("The following classes could not be excluded because they are not auto-configuration classes:%n%s", message));
    }
```
这里是在check需要排除的类存在，但是不在候选配置中的情况。

# 修改
将原注释：
`//检查排除的类是否存在于候选配置中，如果存在，则抛出异常`
修改为：
`// 检查排除的类是否出现在候选配置中，如果需要排除的类存在但没有出现在候选配置中，则抛出异常。`