### PR TITLE
docs: 修正 byte 类型示例中变量数量的小瑕疵

### DIFF
--- a/docs/src/basic-extra-meal/48-keywords.md
+++ b/docs/src/basic-extra-meal/48-keywords.md
@@ -83,7 +83,7 @@ byte minByte = -128;
 byte maxByte = 127;
 ```
 
-在这个示例中，我们声明了三个 byte 类型的变量：minByte、maxByte，并分别赋予了不同的值。
+在这个示例中，我们声明了两个 byte 类型的变量：minByte、maxByte，并分别赋予了不同的值。
 
 ## 5、case：
 


### PR DESCRIPTION
原文描述中称声明了“三个”byte 变量，但示例代码中实际只声明了两个：
minByte 和 maxByte。此处将文字描述更正为“两个”。